### PR TITLE
sensingSecondの値を10分から30秒に変更

### DIFF
--- a/app/src/main/java/net/kajilab/elpissender/Service/SensingWorker.kt
+++ b/app/src/main/java/net/kajilab/elpissender/Service/SensingWorker.kt
@@ -53,7 +53,7 @@ class SensingWorker (
                     firebaseLogger.logSensing("end","センシングを終了しました。")
                     Log.d("SettingViewModel", "センシングが停止しました")
                 },
-                sensingSecond = 10 * 60,
+                sensingSecond = 30,
             )
         }
         return Result.success()


### PR DESCRIPTION
## 概要
> Androidアプリには20分間に滞在管理システムに受信電波リストを送信する．なお，電波受信時間は30秒で行い，30秒の間で受信した電波情報は蓄積され，蓄積されたものをそのまま送信する．

これを実施したい為，センシング時間を10分から30sに変更する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Adjusted sensing operation duration from 10 minutes to 30 seconds, potentially improving performance or addressing a timing-related issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->