### PR TITLE
firebaseをパッケージから削除した，その他バグ回収

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-11-22T06:18:55.272385Z">
+        <DropdownSelection timestamp="2026-03-01T17:53:51.808830Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=48221FDJH0021D" />
@@ -13,7 +13,7 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="PreviewNegativeModelInputDialog">
+      <SelectionState runConfigName="Unnamed">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="migrated" value="true" />
+        <option name="pristineConfig" value="false" />
+        <option name="userId" value="-6abbc2da:18ebaec086b:-8000" />
+        <option name="version" value="8.12.6" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
-    id("com.google.gms.google-services")
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
 }
 

--- a/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/components/WebViewComponent.kt
+++ b/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/components/WebViewComponent.kt
@@ -146,6 +146,9 @@ fun WebViewComponent(
                                     error: WebResourceError?,
                                 ) {
                                     super.onReceivedError(view, request, error)
+                                    if (request?.isForMainFrame != true) {
+                                        return
+                                    }
                                     isLoading = false
                                     hasError = true
                                     errorMessage = "ページの読み込みに失敗しました: ${error?.description}"

--- a/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
+++ b/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
@@ -54,7 +54,7 @@ class SettingViewModel : ViewModel() {
     fun startSensing10second() {
         viewModelScope.launch {
             sensingUsecase?.timerStart(
-                fileName = "",
+                fileName = "debug_10sec",
                 onStopped = {
                     Log.d("SettingViewModel", "センシングが停止しました")
                 },
@@ -72,7 +72,7 @@ class SettingViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             sensingUsecase?.timerStart(
-                fileName = "",
+                fileName = "${sampleType}_room_${roomId}",
                 onStopped = {
                     Log.d("SettingViewModel", "センシングが停止しました")
                     onStopped()
@@ -104,7 +104,7 @@ class SettingViewModel : ViewModel() {
     fun startSensing() {
         viewModelScope.launch {
             sensingUsecase?.start(
-                fileName = "",
+                fileName = "manual_sensing",
             )
         }
     }

--- a/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
+++ b/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
@@ -110,10 +110,12 @@ class SettingViewModel : ViewModel() {
     }
 
     fun stopSensing() {
-        sensingUsecase?.stop(
-            onStopped = {
-                Log.d("SettingViewModel", "センシングが停止しました")
-            },
-        )
+        viewModelScope.launch {
+            sensingUsecase?.stop(
+                onStopped = {
+                    Log.d("SettingViewModel", "センシングが停止しました")
+                },
+            )
+        }
     }
 }

--- a/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
+++ b/app/src/main/java/net/kajilab/elpissender/presenter/ui/view/setting/SettingViewModel.kt
@@ -72,7 +72,7 @@ class SettingViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             sensingUsecase?.timerStart(
-                fileName = "${sampleType}_room_${roomId}",
+                fileName = "${sampleType}_room_$roomId",
                 onStopped = {
                     Log.d("SettingViewModel", "センシングが停止しました")
                     onStopped()

--- a/app/src/main/java/net/kajilab/elpissender/repository/SensingRepository.kt
+++ b/app/src/main/java/net/kajilab/elpissender/repository/SensingRepository.kt
@@ -3,10 +3,6 @@ package net.kajilab.elpissender.repository
 import android.app.Activity
 import android.content.Context
 import android.util.Log
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
-import io.reactivex.rxjava3.core.Single
-import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.schedulers.Schedulers
 import java.io.File
 
 class SensingRepository(context: Context) {
@@ -26,7 +22,9 @@ class SensingRepository(context: Context) {
         samplingFrequency: Double,
     ) {
         require(fileName.isNotBlank()) { "File name cannot be empty" }
-        require(samplingFrequency > 0) { "Sampling frequency must be positive" }
+        require(samplingFrequency == -1.0 || samplingFrequency > 0) {
+            "Sampling frequency must be positive or -1.0"
+        }
         require(sensors.isNotEmpty()) { "Sensors list cannot be empty" }
 
         for (sensor in sensors) {
@@ -44,37 +42,20 @@ class SensingRepository(context: Context) {
         }
     }
 
-    private val compositeDisposable = CompositeDisposable()
-
     fun sensorStop(
         sensors: MutableList<SensorBase>,
         onStopped: (List<File?>) -> Unit,
     ) {
-        val singles =
+        val files =
             sensors.map { sensor ->
-                sensor.stop() // This should return Single<File?>
+                try {
+                    sensor.stop().blockingGet()
+                } catch (e: Exception) {
+                    Log.e(tag, "センサー停止 失敗", e)
+                    null
+                }
             }
-
-        compositeDisposable.add(
-            Single.zip(singles) { results ->
-                results.map { it as File? }
-            }
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                    { files ->
-                        Log.d(tag, "センサー停止 成功")
-                        // センサーが終了した時にMainActivityに伝える。
-                        onStopped(files)
-                    },
-                    { e ->
-                        Log.e(tag, "センサー停止 失敗", e)
-                    },
-                ),
-        )
-    }
-
-    fun onCleared() {
-        compositeDisposable.clear()
+        Log.d(tag, "センサー停止 完了")
+        onStopped(files)
     }
 }

--- a/app/src/main/java/net/kajilab/elpissender/repository/SensingRepository.kt
+++ b/app/src/main/java/net/kajilab/elpissender/repository/SensingRepository.kt
@@ -3,6 +3,8 @@ package net.kajilab.elpissender.repository
 import android.app.Activity
 import android.content.Context
 import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 class SensingRepository(context: Context) {
@@ -42,17 +44,19 @@ class SensingRepository(context: Context) {
         }
     }
 
-    fun sensorStop(
+    suspend fun sensorStop(
         sensors: MutableList<SensorBase>,
         onStopped: (List<File?>) -> Unit,
     ) {
         val files =
-            sensors.map { sensor ->
-                try {
-                    sensor.stop().blockingGet()
-                } catch (e: Exception) {
-                    Log.e(tag, "センサー停止 失敗", e)
-                    null
+            withContext(Dispatchers.IO) {
+                sensors.map { sensor ->
+                    try {
+                        sensor.stop().blockingGet()
+                    } catch (e: Exception) {
+                        Log.e(tag, "センサー停止 失敗", e)
+                        null
+                    }
                 }
             }
         Log.d(tag, "センサー停止 完了")

--- a/app/src/main/java/net/kajilab/elpissender/service/SensingWorker.kt
+++ b/app/src/main/java/net/kajilab/elpissender/service/SensingWorker.kt
@@ -45,7 +45,7 @@ class SensingWorker(
         serviceScope.launch {
             logSendRepository.sendLog("start", "センシングを開始しました", 1)
             sensingUsecase.timerStart(
-                fileName = "",
+                fileName = "worker_sensing",
                 onStopped = {
                     logSendRepository.sendLog("end", "センシングを終了しました。", 1)
                     Log.d("SettingViewModel", "センシングが停止しました")

--- a/app/src/main/java/net/kajilab/elpissender/usecase/SensingUsecase.kt
+++ b/app/src/main/java/net/kajilab/elpissender/usecase/SensingUsecase.kt
@@ -14,6 +14,7 @@ import net.kajilab.elpissender.repository.SensingRepository
 import net.kajilab.elpissender.repository.SensorBase
 import net.kajilab.elpissender.repository.UserRepository
 import net.kajilab.elpissender.repository.WiFiRepository
+import net.kajilab.elpissender.utils.DateUtils
 import java.io.File
 
 class SensingUsecase(
@@ -86,9 +87,10 @@ class SensingUsecase(
         addSensor(context = context)
 
         val samplingFrequency = -1.0
+        val resolvedFileName = resolveFileName(fileName)
         coroutineScope.launch {
             sensorRepository.sensorStart(
-                fileName = fileName,
+                fileName = resolvedFileName,
                 sensors = targetSensors,
                 samplingFrequency = samplingFrequency,
             )
@@ -130,8 +132,6 @@ class SensingUsecase(
             },
         )
         targetSensors = mutableListOf() // センサーをリセット
-
-        sensorRepository.onCleared() // メモリーリークを防止する
     }
 
     suspend fun timerStart(
@@ -177,5 +177,10 @@ class SensingUsecase(
     private fun addSensor(context: Context) {
         targetSensors.add(BLERepository(context))
         targetSensors.add(WiFiRepository(context))
+    }
+
+    private fun resolveFileName(fileName: String): String {
+        val normalized = fileName.trim()
+        return normalized.ifBlank { "sensing_${DateUtils.getNowDate()}" }
     }
 }

--- a/app/src/main/java/net/kajilab/elpissender/usecase/SensingUsecase.kt
+++ b/app/src/main/java/net/kajilab/elpissender/usecase/SensingUsecase.kt
@@ -75,11 +75,13 @@ class SensingUsecase(
     fun finalStop() {
         scanFlag = false
         if (targetSensors.isNotEmpty()) {
-            stop(
-                onStopped = {
-                    Log.d("SensingService", "BackGroundで一回実行されたよ")
-                },
-            )
+            coroutineScope.launch {
+                stop(
+                    onStopped = {
+                        Log.d("SensingService", "BackGroundで一回実行されたよ")
+                    },
+                )
+            }
         }
     }
 
@@ -97,7 +99,7 @@ class SensingUsecase(
         }
     }
 
-    fun stop(
+    suspend fun stop(
         onStopped: () -> Unit,
         onSend: ((List<File?>) -> Unit)? = null,
     ) {
@@ -180,7 +182,13 @@ class SensingUsecase(
     }
 
     private fun resolveFileName(fileName: String): String {
-        val normalized = fileName.trim()
-        return normalized.ifBlank { "sensing_${DateUtils.getNowDate()}" }
+        val normalized =
+            fileName
+                .trim()
+                .ifBlank { "sensing_${DateUtils.getNowDate()}" }
+
+        return normalized
+            .replace(Regex("""[\\/:*?"<>|]"""), "_")
+            .replace(Regex("""\.\.+"""), "_")
     }
 }


### PR DESCRIPTION

**背景**
- Firebase を現在使っていない構成にもかかわらず `com.google.gms.google-services` プラグインが有効になっており、`google-services.json` 不足で `Debug` ビルドが失敗していた。
- センシング開始時に空の `fileName` が渡される経路があり、`File name cannot be empty` でアプリがクラッシュしていた。
- `Negativeモデルを送信する` などの短時間計測で、計測自体は終わっていても停止完了の通知が UI まで返らず、「計測中」のまま終了しないことがあった。
- WebView でサブリソース読込エラーまで画面全体のエラーとして扱っていたため、`ERR_CLEARTEXT_NOT_PERMITTED` 発生時にページ全体が見えなくなるケースがあった。

**実施内容**
- `app/build.gradle.kts` から未使用の `com.google.gms.google-services` プラグインを削除し、`google-services.json` なしでも `Debug` ビルドできるようにした。
- `SensingUsecase` で空の `fileName` をそのまま流さず、空の場合は日時付きのデフォルト名に補完するようにした。
- `SettingViewModel` / `SensingWorker` からのセンシング開始時に、用途が分かるファイル名を渡すように変更した。
- `SensingRepository` の `samplingFrequency` バリデーションを見直し、実装で利用している `-1.0` を有効値として扱うようにした。
- `SensingRepository` の停止処理を見直し、各センサー停止後に確実に `onStopped` を返すように変更した。
- `SensingUsecase` 側の不要なクリーンアップ呼び出しを外し、停止完了前に後続処理が切れる状態を解消した。
- `WebViewComponent` では main frame の読込失敗のみを画面エラー扱いとし、サブリソース失敗でページ全体を閉じないようにした。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * WebViewコンポーネントのエラー処理を改善し、メインフレームのエラーのみを適切に処理するようにしました。

* **その他**
  * 内部の非同期処理フレームワークを最適化し、より効率的な処理フローに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->